### PR TITLE
Fix: Use direct function call for login form to prevent shortcode issues

### DIFF
--- a/index.php
+++ b/index.php
@@ -344,7 +344,14 @@
     <!-- Hidden file input -->
     <input type="file" class="file-input" id="avatarFileInput" accept="image/*">
     <!-- Hidden containers for WordPress to render shortcodes -->
-    <div id="um-login-render-container" style="display: none;"><?php echo do_shortcode('[tt_login_form]'); ?></div>
+    <div id="um-login-render-container" style="display: none;"><?php
+    if (function_exists('tt_login_form_shortcode')) {
+        echo tt_login_form_shortcode();
+    } else {
+        // Fallback to original behavior if function doesn't exist for some reason
+        echo do_shortcode('[tt_login_form]');
+    }
+    ?></div>
 
     <script id="tt-patch-2025-08-18">
     (() => {


### PR DESCRIPTION
Replaced the `do_shortcode('[tt_login_form]')` call in `index.php` with a direct call to the `tt_login_form_shortcode()` function.

This change is intended to make the rendering of the login form more robust. By calling the function directly, we bypass the WordPress shortcode processing system, which can be affected by environmental issues like caching or plugin conflicts.

A `function_exists()` check is included to ensure the site does not break if the theme's `functions.php` file fails to load. In that case, it falls back to the original `do_shortcode` behavior.